### PR TITLE
fix select box padding issue

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -9,6 +9,10 @@ input[type=number] {
 -moz-appearance: textfield;
 }
 
+select {
+  padding-right: 3.5rem;
+}
+
 // Checkboxes
 .sba-c-checkbox + .sba-c-label {
   padding-left: 3rem;

--- a/lib/certify_design_system/version.rb
+++ b/lib/certify_design_system/version.rb
@@ -6,5 +6,5 @@ module CertifyDesignSystem
   #    MAJOR version when you make incompatible API changes,
   #    MINOR version when you add functionality in a backwards-compatible manner, and
   #    PATCH version when you make backwards-compatible bug fixes.
-  VERSION = '1.11.0'
+  VERSION = '1.11.1'
 end


### PR DESCRIPTION
Fixes issue with select boxes where content collides with arrow:

Before:
<img width="331" alt="screen shot 2018-06-22 at 3 22 09 pm" src="https://user-images.githubusercontent.com/25435289/41795269-2895c24e-7630-11e8-9cef-5a65d3707384.png">

After:
<img width="326" alt="screen shot 2018-06-22 at 3 22 16 pm" src="https://user-images.githubusercontent.com/25435289/41795280-31681354-7630-11e8-9415-99cbf8dcbcf0.png">

